### PR TITLE
Non cell type markers

### DIFF
--- a/ClassifyCells_Analyses.R
+++ b/ClassifyCells_Analyses.R
@@ -13,7 +13,6 @@ antibody_colors = data.frame(antibody_mouse = c("B220","CD4","CD8","F4/80","othe
 maxSizePlot_inches = 20
 cellSizePlot_um = 100
 boundary_thickness = 2
-# prolif_color = "deepskyblue"
 #################################
 
 ########## Functions ##########
@@ -84,7 +83,6 @@ classify_cells = function(quant, ll_config){
       quant[,paste0(marker,"+")] = quant[,marker]>ll_config[marker,"calibrated_thresholds"]
    }
 
-   # quant[,"is_proliferating"] = as.numeric(quant[,"Ki67"])>ll_config["Ki67","calibrated_thresholds"]
    return(quant)
 }
 

--- a/ClassifyCells_Analyses.R
+++ b/ClassifyCells_Analyses.R
@@ -1,17 +1,19 @@
 
 ########## Input ##########
-MainDir = "/mnt/data1/Daniele/elisa_lymphomoids/test2/" # Absolute path to your main directory
-ConfigTable = "/mnt/data1/Daniele/elisa_lymphomoids/Lymphomoid-IF-pipeline/human_channels.txt" # Configuration table as 'mouse_channels.txt' or 'human_channels.txt' 
+MainDir = "/mnt/ndata/varrone/Packages/Lymphomoid-IF-pipeline/output_example/" # Absolute path to your main directory
+ConfigTable = "/mnt/ndata/varrone/Packages/Lymphomoid-IF-pipeline/human_channels.txt" # Configuration table as 'mouse_channels.txt' or 'human_channels.txt' 
 Lymphomoids_to_process = "all" # "all", or vector of boundary file names (e.g. Lymphomoids_to_process = c( "HLS01_s02_acq03_Pembroluzimab01_Boundary.txt", "HLS01_s02_acq03_Pembroluzimab02_Boundary.txt" ) )
 ###########################
 
 ###### Plotting parameters ######
 plot_IF_images = TRUE # TRUE or FALSE. FALSE makes the script run faster.
+
+# ToDo: there could be arbitrary channels, so use a palette
 antibody_colors = data.frame(antibody_mouse = c("B220","CD4","CD8","F4/80","otherCell"), antibody_human = c("CD20","CD4","CD8","CD68","otherCell"), color = c("green","yellow","cyan","magenta","gray"), stringsAsFactors = F)
 maxSizePlot_inches = 20
 cellSizePlot_um = 100
 boundary_thickness = 2
-prolif_color = "deepskyblue"
+# prolif_color = "deepskyblue"
 #################################
 
 ########## Functions ##########
@@ -20,9 +22,14 @@ library(ggplot2)
 library(reshape2)
 
 parse_boundary = function(pl, pixelSize){
+   # Parse the boundary file to get the coordinates of the boundary points
    pl_points = unlist(strsplit(as.character(pl[1,"V1"]), split=";"))
+
+   # Initialize a data frame to store the coordinates
    plp_df = data.frame(x = rep(NA,length(pl_points)+1), y = rep(NA,length(pl_points)+1))
    index = 1
+
+   # Loop through each point and extract the coordinates
    for (point in pl_points)
    {
       poiSpl = unlist(strsplit(point, split = ", "))
@@ -30,16 +37,27 @@ parse_boundary = function(pl, pixelSize){
       plp_df[index,"y"] = (as.numeric((poiSpl[2])))*pixelSize
       index = index+1
    }
+
+   # Close the loop by connecting the last point to the first point
    plp_df[nrow(plp_df),"x"] = plp_df[1,"x"]
    plp_df[nrow(plp_df),"y"] = plp_df[1,"y"]
    return(plp_df)
 }
 
 classify_cells = function(quant, ll_config){
-   this_inte = sweep(quant[,rownames(ll_config)[!(rownames(ll_config) %in% c( "DAPI","Ki67" ))] ],2,ll_config[rownames(ll_config)[!(rownames(ll_config) %in% c( "DAPI","Ki67" ))],"calibrated_thresholds"])
+   # Classify cells based on the thresholded intensity values only for the cell type markers
+   this_inte = sweep(quant[,rownames(ll_config)[ll_config$Is_CellType_Marker]],2,ll_config[rownames(ll_config)[ll_config$Is_CellType_Marker],"calibrated_thresholds"])
+   
+   # Identify cells that have positive intensity values for any marker
    is_cell = rowSums(this_inte>0)>0
+
+   # Filter the intensity data to only include cells that are classified as cells
    this_inte = this_inte[is_cell %in% c(T),]
+   
+   # Find the index of the maximum intensity value for each cell
    inteMax = apply(this_inte,1,which.max)
+   
+   # Add spatial coordinates and cell type indices to the quantification data
    quant$spatial_1 = quant$X_centroid_nucleus*pixelSize
    quant$spatial_2 = quant$Y_centroid_nucleus*pixelSize
    quant$CellType_index = 0
@@ -47,23 +65,35 @@ classify_cells = function(quant, ll_config){
    quant$CellType_color = "gray"
    quant$CellType_antibody = "otherCell"
    quant$CellType_marker = "otherCell"
+   
+   # Assign colors, antibodies, and markers based on the maximum intensity index
    for (index in 1:4)
    {
       quant[quant$CellType_index==index,"CellType_color"] = antibody_colors[colnames(this_inte)[index],"color"]
       quant[quant$CellType_index==index,"CellType_antibody"] = colnames(this_inte)[index]
       quant[quant$CellType_index==index,"CellType_marker"] = ll_config[colnames(this_inte)[index],"Marker_of"]
    }
+   
    quant$CellType_marker = factor(quant$CellType_marker, levels = c("otherCell",ll_config[colnames(this_inte),"Marker_of"]))
    quant$CellType_antibody = factor(quant$CellType_antibody, levels = c("otherCell",colnames(this_inte)))
    quant$CellType_index = NULL
-   quant[,"is_proliferating"] = as.numeric(quant[,"Ki67"])>ll_config["Ki67","calibrated_thresholds"]
+
+   # For every non-cell type marker taken from the configuration table, add a column indicating whether the cell is positive or negative for that marker
+   for (marker in ll_config[ll_config$Is_CellType_Marker == FALSE & ll_config$Antibody != "DAPI", "Antibody"])
+   {
+      quant[,paste0(marker,"+")] = quant[,marker]>ll_config[marker,"calibrated_thresholds"]
+   }
+
+   # quant[,"is_proliferating"] = as.numeric(quant[,"Ki67"])>ll_config["Ki67","calibrated_thresholds"]
    return(quant)
 }
 
-plot_digital_image = function(fileName, quant, plp_df, withOtherCells = T, onlyInLymphomoid = F, onlyProliferating = F){
-   if (onlyProliferating) { quant = quant[quant$is_proliferating,] }
+plot_digital_image = function(fileName, quant, plp_df, withOtherCells = T, onlyInLymphomoid = F, nonCellTypeMarker = NULL){
    if (!withOtherCells) { quant = quant[quant$CellType_antibody != "otherCell",] }
    if (onlyInLymphomoid) { quant = quant[quant$in_lymphomoid,] }
+   # If a non-cell type marker is provided, plot only cells that have column "marker_positive" equal to TRUE
+   if (!is.null(nonCellTypeMarker)) { quant = quant[quant[,paste0(nonCellTypeMarker,"+")]==TRUE,] }
+   
    abdf = data.frame(row.names = as.character(unique(quant$CellType_antibody)), ab = as.character(unique(quant$CellType_antibody)), color = unique(quant$CellType_color), stringsAsFactors = F)
    colorz = abdf[intersect(levels(quant$CellType_antibody),rownames(abdf)),"color"]
    widthz = max(c(quant$spatial_1,plp_df$x))-min(c(quant$spatial_1,plp_df$x))
@@ -77,16 +107,26 @@ plot_digital_image = function(fileName, quant, plp_df, withOtherCells = T, onlyI
    return(p)
 }
 
+# Function to plot proportions of different cell types in each sample
 plot_CellTypeProportions = function(markers, ldf, OutFileRoot){
+   # Get colors for each marker from antibody_colors table
    colors = antibody_colors[markers,"color"]
+   
+   # Calculate proportions of each marker relative to total cells
    cdf = ldf[,markers]/apply(ldf[,markers],1,sum)
    cdf$Sample = rownames(cdf)
+   
+   # Write proportions to output file
    write.table(cdf, file = paste0(MainDir,OutFileRoot,".txt"), quote = F, col.names = T, row.names = T, sep = "\t")
+   
+   # Reshape data for plotting
    cdf = melt(cdf,id="Sample")
    cdf = merge(cdf,ldf[,c("PatientLymphomoidName","TotalCells")],by.x = "Sample", by.y = "row.names")
    cdf$variable = factor(cdf$variable, levels = markers)
    cdf$Sample = factor(cdf$Sample, levels = rownames(ldf))
    cdf$TotalCells = paste0("N=",round(cdf$TotalCells))
+   
+   # Create stacked bar plot
    pdf(paste0(MainDir,OutFileRoot,".pdf"),2*nrow(ldf),6)
    p = ggplot(data=cdf, aes(x=Sample, y=value, fill=variable)) +
       geom_bar(stat="identity", colour="black", size = 0.5) + ylab("Proportion") + xlab("") + scale_fill_manual(name = "Marker",values=colors) + theme_bw() + theme(axis.text.x = element_text(angle = 45, hjust = 1)) + scale_x_discrete(labels=rownames(ldf)) +
@@ -96,29 +136,87 @@ plot_CellTypeProportions = function(markers, ldf, OutFileRoot){
    return(p)
 }
 
-plot_ProlifVsNot = function(markers, ldf, OutFileRoot){
-   colors = antibody_colors[markers,"color"]
-   for (marker in markers)
-   {
-      cdf = ldf[,c(marker,paste0("prolif_",marker))]
-      total = cdf[,marker]
-      cdf[,marker] = cdf[,marker]-cdf[,paste0("prolif_",marker)]
-      cdf = cdf/total
-      colnames(cdf) = c("Not proliferating","Proliferating")
-      cdf$Sample = rownames(cdf)
-      write.table(cdf, file = paste0(MainDir,OutFileRoot,gsub("/","-",marker),".txt"), quote = F, col.names = T, row.names = T, sep = "\t")
-      cdf = melt(cdf,id="Sample")
-      cdf = merge(cdf,ldf[,c("PatientLymphomoidName",marker )],by.x = "Sample", by.y = "row.names")
-      colnames(cdf)[colnames(cdf)==marker] = "TotalCells"
-      cdf$variable = factor(cdf$variable, levels = c("Not proliferating","Proliferating"))
-      cdf$Sample = factor(cdf$Sample, levels = rownames(ldf))
-      cdf$TotalCells = paste0("N=",round(cdf$TotalCells))
-      pdf(paste0(MainDir,OutFileRoot,gsub("/","-",marker),".pdf"),2*nrow(ldf),6)
-      p = ggplot(data=cdf, aes(x=Sample, y=value, fill=variable)) +
-         geom_bar(stat="identity", colour="black", size = 0.5) + ylab("Proportion") + xlab("") + scale_fill_manual(name = marker,values=c(colors[which(marker==markers)],prolif_color)) + theme_bw() + theme(axis.text.x = element_text(angle = 45, hjust = 1)) + scale_x_discrete(labels=rownames(ldf)) +
-         geom_text(aes(label=TotalCells,y=1),vjust=-0.2)
-      print(p)
-      dev.off()
+# Function to plot positive vs negative proportions for each marker and cell type combination
+plot_NonCellTypeMarker = function(cell_type_markers, non_cell_type_markers, ldf, OutFileRoot) {
+   # Get colors for each cell type marker
+   colors = antibody_colors[cell_type_markers,"color"]
+   
+   # For each cell type marker
+   for (cell_marker in cell_type_markers) {
+      # Skip if the cell marker is "otherCell"
+      if (cell_marker == "otherCell") next
+      
+      # For each non-cell type marker (e.g., Ki67, CD68)
+      for (other_marker in non_cell_type_markers) {
+         
+         # Find all columns that match this cell type and marker
+         matching_cols = grep(paste0("^", cell_marker, ".*", other_marker, "[+-]"), colnames(ldf), value=TRUE)
+         
+         if (length(matching_cols) == 0) {
+            print(paste("No data found for", cell_marker, "and", other_marker))
+            next
+         }
+         
+         # Sum positive and negative counts
+         positive_cols = grep(paste0(other_marker, "\\+"), matching_cols, value=TRUE)
+         negative_cols = grep(paste0(other_marker, "\\-"), matching_cols, value=TRUE)
+         
+         # Create dataframe for plotting
+         cdf = data.frame(
+            Negative = rowSums(ldf[, negative_cols, drop=FALSE]),
+            Positive = rowSums(ldf[, positive_cols, drop=FALSE])
+         )
+         
+         # Calculate total cells for this cell type
+         total = cdf$Negative + cdf$Positive
+         
+         # Skip if no cells of this type
+         if (all(total == 0)) {
+            print(paste("No cells found for", cell_marker))
+            next
+         }
+         
+         # Convert to proportions
+         cdf = cdf/total
+         cdf$Sample = rownames(cdf)
+         
+         # Write proportions to output file
+         write.table(cdf, 
+                    file = paste0(MainDir, OutFileRoot, gsub("/","-",cell_marker), "_", other_marker, ".txt"), 
+                    quote = F, col.names = T, row.names = T, sep = "\t")
+         
+         # Reshape data for plotting
+         cdf = melt(cdf, id="Sample")
+         cdf = merge(cdf, 
+                    data.frame(Sample = rownames(ldf), 
+                             TotalCells = total,
+                             PatientLymphomoidName = ldf$PatientLymphomoidName,
+                             row.names = NULL), 
+                    by = "Sample")
+         
+         cdf$variable = factor(cdf$variable, levels = c("Negative", "Positive"))
+         cdf$Sample = factor(cdf$Sample, levels = rownames(ldf))
+         cdf$TotalCells = paste0("N=", round(cdf$TotalCells))
+         
+         # Create stacked bar plot
+         pdf(paste0(MainDir, OutFileRoot, gsub("/","-",cell_marker), "_", other_marker, ".pdf"), 
+             2*nrow(ldf), 6)
+         
+         p = ggplot(data=cdf, aes(x=Sample, y=value, fill=variable)) +
+            geom_bar(stat="identity", colour="black", size = 0.5) + 
+            ylab("Proportion") + 
+            xlab("") + 
+            ggtitle(paste(cell_marker, other_marker, "status")) +
+            scale_fill_manual(name = paste(other_marker, "status"),
+                            values=c(colors[which(cell_marker==cell_type_markers)], "deepskyblue")) + 
+            theme_bw() + 
+            theme(axis.text.x = element_text(angle = 45, hjust = 1)) + 
+            scale_x_discrete(labels=cdf$PatientLymphomoidName) +  # Use PatientLymphomoidName for labels
+            geom_text(aes(label=TotalCells,y=1), vjust=-0.2)
+         
+         print(p)
+         dev.off()
+      }
    }
    return(p)
 }
@@ -130,29 +228,54 @@ channels = read.table( file = ConfigTable, sep = "\t", header = T, quote = '' ,s
 dir.create(paste0(MainDir,"Digital_IF_images/"), showWarnings = F)
 dir.create(paste0(MainDir,"Classified_cells_tables/"), showWarnings = F)
 if (Lymphomoids_to_process=="all"){ Lymphomoids_to_process = list.files(paste0( MainDir,"Lymphomoid_boundaries/" ), pattern = "Boundary.txt") }
-if (length(intersect(channels$Antibody,antibody_colors$antibody_mouse))==4 ) rownames(antibody_colors) = antibody_colors$antibody_mouse
-if (length(intersect(channels$Antibody,antibody_colors$antibody_human))==4 ) rownames(antibody_colors) = antibody_colors$antibody_human
-all_markerz = c("otherCell", channels$Antibody[!(channels$Antibody %in% c( "DAPI","Ki67" ))])
-all_colz = c("ImageName","PatientLymphomoidName",all_markerz, paste0("prolif_",all_markerz ),"TotalCells")
+
+# Set antibody colors based on whether mouse or human antibodies are used
+if (grepl("mouse_channels.txt", ConfigTable)) {
+  rownames(antibody_colors) = antibody_colors$antibody_mouse
+} else if (grepl("human_channels.txt", ConfigTable)) {
+  rownames(antibody_colors) = antibody_colors$antibody_human
+}
+
+# Extract cell type markers
+cell_type_markerz = c("otherCell", channels$Antibody[channels$Is_CellType_Marker == TRUE])
+other_markerz = channels$Antibody[channels$Is_CellType_Marker == FALSE]
+
+# Create column names for summary table
+# ToDo: add non-cell type markers in every possible negative and positive combination
+all_colz = c("ImageName","PatientLymphomoidName", cell_type_markerz, "TotalCells")
+
+# Initialize empty summary dataframe
 tdf = data.frame(matrix(nrow = 0, ncol = length(all_colz), dimnames = list(NULL,all_colz)))
+
+# Fix F4/80 naming inconsistency
 colnames(tdf)[colnames(tdf)=="F4.80"] = "F4/80"
-colnames(tdf)[colnames(tdf)=="prolif_F4.80"] = "prolif_F4/80"
+
+# Initialize vectors to track processed files for logging
 quant_file_vec = c() # for log file
 calib_file_vec = c() # for log file
+
+# Process each lymphoid region
 for (ll in Lymphomoids_to_process)
 {
    cat("\n","Processing",ll,"...","\n" )
-   ## Parsing and reading
+   
+   ## Extract image and lymphoid region names from filename
    ImageName = sub("_[^_]+$", "", substr(ll,1,nchar(ll)-13))
    PatientLymphomoidName = substr(ll,nchar(ImageName)+2,nchar(ll)-13)
+   
+   # Load quantification data
    quant_file = paste0(MainDir,"Quantification/",ImageName,"/quantification/mesmer-",ImageName,"_merged.csv")
    quant_file_vec = c(quant_file_vec,substr(quant_file,nchar(MainDir)+1,nchar(quant_file)))
    if (!file.exists(quant_file)) { 
       cat("\n","Attention!",quant_file,"does not exist. Moving on to the next lymphomoid...","\n" )
       next }
    quant = read.csv(quant_file,stringsAsFactors = F)
+   
+   # Remove unnecessary morphological measurements from quantification data
    quant = quant[,!(colnames(quant) %in% c( "Area_nucleus","MajorAxisLength_nucleus","MinorAxisLength_nucleus","Eccentricity_nucleus","Solidity_nucleus","Extent_nucleus","Orientation_nucleus","X_centroid_cytoplasm","Y_centroid_cytoplasm","Area_cytoplasm","MajorAxisLength_cytoplasm","MinorAxisLength_cytoplasm","Eccentricity_cytoplasm","Solidity_cytoplasm","Extent_cytoplasm","Orientation_cytoplasm" ))]
    colnames(quant)[colnames(quant)=="F4.80"] = "F4/80"
+   
+   # Load calibration thresholds
    calib_file = paste0(MainDir,"Calibrated_thresholds/",ImageName,"_AllThresholds.txt")
    calib_file_vec = c(calib_file_vec,substr(calib_file,nchar(MainDir)+1,nchar(calib_file)))
    if (!file.exists(calib_file)) { 
@@ -162,37 +285,47 @@ for (ll in Lymphomoids_to_process)
       next }}
    calib = read.table( file = calib_file, sep = " ", header = F, quote = '' ,stringsAsFactors = F)
    rownames(calib) = calib$V1
+   
+   # Load and parse lymphoid boundary coordinates
    pl = read.table(file = paste0(MainDir,"Lymphomoid_boundaries/",ll), sep = "-")
    pixelSize = as.numeric(substr(as.character(pl[2,"V1"]),10,nchar(as.character(pl[2,"V1"]))))
    plp_df = parse_boundary(pl,pixelSize)
 
-   ## Setting up config table of this lymphomoid
+   ## Configure thresholds for this lymphoid region
    ll_config = channels
    rownames(ll_config) = paste0(sub(" .*", "", ll_config$Channel_name),"_thresh")
    ll_config$calibrated_thresholds = calib[rownames(ll_config),"V2"]
    rownames(ll_config) = ll_config$Antibody
 
-   ## Classifying cells and checking which ones are inside the lymphomoid
+   ## Classify cells and identify those within lymphoid boundary
    quant = classify_cells(quant, ll_config)
    inPolygon = point.in.polygon(point.x = quant$spatial_1, point.y = quant$spatial_2, pol.x = plp_df$x, pol.y = plp_df$y)
    quant$in_lymphomoid = inPolygon==1
 
-   ## Plotting digital IF images
+   ## Generate visualization plots if requested
    if (plot_IF_images)
    {
       fileName = paste0(MainDir,"Digital_IF_images/","IFimage_",ImageName,"_",PatientLymphomoidName,"_all.pdf")
-      p = plot_digital_image(fileName, quant, plp_df, withOtherCells = T, onlyInLymphomoid = F, onlyProliferating = F)
-      fileName = paste0(MainDir,"Digital_IF_images/","IFimage_",ImageName,"_",PatientLymphomoidName,"_NoOtherCells_OnlyInLymphomoid_.pdf")
-      p = plot_digital_image(fileName, quant, plp_df, withOtherCells = F, onlyInLymphomoid = T, onlyProliferating = F)
-      fileName = paste0(MainDir,"Digital_IF_images/","IFimage_",ImageName,"_",PatientLymphomoidName,"_NoOtherCells_OnlyInLymphomoid_OnlyProliferating.pdf")
-      p = plot_digital_image(fileName, quant, plp_df, withOtherCells = F, onlyInLymphomoid = T, onlyProliferating = T)
+      p = plot_digital_image(fileName, quant, plp_df, withOtherCells = T, onlyInLymphomoid = F, nonCellTypeMarker = NULL)
+      fileName = paste0(MainDir,"Digital_IF_images/","IFimage_",ImageName,"_",PatientLymphomoidName,"_NoOtherCells_OnlyInLymphomoid.pdf")
+      p = plot_digital_image(fileName, quant, plp_df, withOtherCells = F, onlyInLymphomoid = T, nonCellTypeMarker = NULL)
+
+      for (marker in other_markerz)
+      {
+         if (marker != "DAPI") {
+            fileName = paste0(MainDir,"Digital_IF_images/","IFimage_",ImageName,"_",PatientLymphomoidName,"_NoOtherCells_OnlyInLymphomoid_",marker,".pdf")
+            p = plot_digital_image(fileName, quant, plp_df, withOtherCells = F, onlyInLymphomoid = T, nonCellTypeMarker = marker)
+         }
+      }
    }
    
-   ## Saving data
+   ## Clean up and save cell data
    quant$X_centroid_nucleus = NULL
    quant$Y_centroid_nucleus = NULL
    colnames(quant)[colnames(quant) %in% c( "spatial_1","spatial_2" )] = c( "x_centroid_nucleus_um","y_centroid_nucleus_um" )
    quant = quant[quant$in_lymphomoid,]
+   
+   # Skip if too few cells found
    if (nrow(quant) < 10 ) { 
       cat( "\n","*** Warning: less than 10 cells inside the boundary! check the IF images under 'Digital_IF_images/' to see what is the problem", "\n" )
       cat( "\n","*** Skipping",ll, "\n" )
@@ -200,37 +333,70 @@ for (ll in Lymphomoids_to_process)
    }
    write.table(quant, file = paste0(MainDir,"Classified_cells_tables/Table_",ImageName,"_",PatientLymphomoidName,"_AllCells.txt"), row.names = F, col.names = T, quote = F, sep = "\t")
 
-   ## Concatenating summary for all lymphomoids
+   ## Create summary statistics for this lymphoid region
    ttdf = data.frame(matrix(0,nrow = 1, ncol = length(all_colz), dimnames = list(paste0(ImageName,"_",PatientLymphomoidName),all_colz)))
    colnames(ttdf)[colnames(ttdf)=="F4.80"] = "F4/80"
-   colnames(ttdf)[colnames(ttdf)=="prolif_F4.80"] = "prolif_F4/80"
    ttdf[, c( "ImageName","PatientLymphomoidName" )] = c( ImageName,PatientLymphomoidName )
+
+   # Add cell type counts
    ttdf[,names(table(quant$CellType_antibody))] = as.numeric(table(quant$CellType_antibody))
    ttdf[,"TotalCells"] = sum(as.numeric(table(quant$CellType_antibody)))
-   ttdf[,paste0("prolif_",rownames(table(quant$CellType_antibody,quant$is_proliferating)))] = as.numeric(table(quant$CellType_antibody,quant$is_proliferating)[,"TRUE"])
+
+   # Get markers that aren't used for cell type classification
+   non_celltype_markers = rownames(ll_config)[!ll_config$Is_CellType_Marker & ll_config$Antibody != "DAPI"]
+   marker_names = ll_config[non_celltype_markers, "Antibody"]
+
+   # Extract the counts for all combinations of cell_type marker and non-cell type markers
+   for (cell_type_marker in cell_type_markerz) {
+     
+     # Generate all combinations of non-cell type markers
+     combinations = expand.grid(lapply(marker_names, function(x) c(TRUE, FALSE)))
+     colnames(combinations) = marker_names
+     
+     # Add columns for each combination to the ttdf data frame
+     for (i in 1:nrow(combinations)) {
+       combination = combinations[i, ]
+       combination_name = paste0(cell_type_marker, "_", paste0(names(combination), ifelse(combination, "+", "-"), collapse = "_"))
+       
+       # Count cells matching the combination, treating NA as FALSE
+       ttdf[, combination_name] = sum(quant$CellType_antibody == cell_type_marker & 
+         apply(quant[, paste0(marker_names, "+")], 1, function(row) {
+           all(ifelse(is.na(row), FALSE, row) == combination)
+         }))
+     }
+   }
+
    tdf = rbind(tdf, ttdf)
-   
 }
 
 ## Saving and plotting at the image X lymphomoid level
 dir.create(paste0(MainDir,"Results_ImageXLymphomoid_level/"),showWarnings = F)
 save(tdf, file = paste0(MainDir,"Results_ImageXLymphomoid_level/SummaryTable_ImageXLymphomoid_AllCells.RData"))
 write.table(tdf, file = paste0(MainDir,"Results_ImageXLymphomoid_level/SummaryTable_ImageXLymphomoid_AllCells.txt"), row.names = F, col.names = T, quote = F, sep = "\t")
-p = plot_CellTypeProportions(markers = all_markerz, ldf = tdf, OutFileRoot = "Results_ImageXLymphomoid_level/ImageXLymphomoidLevel_CellTypeProportions_StackedBarplot")
-p = plot_CellTypeProportions(markers = all_markerz[all_markerz!="otherCell"], ldf = tdf, OutFileRoot = "Results_ImageXLymphomoid_level/ImageXLymphomoidLevel_CellTypeProportions_ExclOtherCells_StackedBarplot")
-p = plot_ProlifVsNot(markers = all_markerz[all_markerz!="otherCell"], ldf = tdf, OutFileRoot = "Results_ImageXLymphomoid_level/ImageXLymphomoidLevel_ProlifVsNot_")
+p = plot_CellTypeProportions(markers = cell_type_markerz, ldf = tdf, OutFileRoot = "Results_ImageXLymphomoid_level/ImageXLymphomoidLevel_CellTypeProportions_StackedBarplot")
+p = plot_CellTypeProportions(markers = cell_type_markerz[cell_type_markerz!="otherCell"], ldf = tdf, OutFileRoot = "Results_ImageXLymphomoid_level/ImageXLymphomoidLevel_CellTypeProportions_ExclOtherCells_StackedBarplot")
+p = plot_NonCellTypeMarker(
+   cell_type_markers = cell_type_markerz[cell_type_markerz!="otherCell"], 
+   non_cell_type_markers = other_markerz[other_markerz != "DAPI"],
+   ldf = tdf, 
+   OutFileRoot = "Results_ImageXLymphomoid_level/ImageXLymphomoidLevel_MarkerStatus_"
+)
 
-## Consolidating the same lymphomoid across images, saving and plotting
+# ## Consolidating the same lymphomoid across images, saving and plotting
 tdf$ImageName = NULL
 ldf = aggregate(.~PatientLymphomoidName, data = tdf, FUN=mean)
 rownames(ldf) = ldf$PatientLymphomoidName
 save(ldf, file = paste0(MainDir,"SummaryTable_LymphomoidLevel_AllCells.RData"))
 write.table(ldf, file = paste0(MainDir,"SummaryTable_LymphomoidLevel_AllCells.txt"), row.names = F, col.names = T, quote = F, sep = "\t")
-p = plot_CellTypeProportions(markers = all_markerz, ldf = ldf, OutFileRoot = "LymphomoidLevel_CellTypeProportions_StackedBarplot")
-p = plot_CellTypeProportions(markers = all_markerz[all_markerz!="otherCell"], ldf = ldf, OutFileRoot = "LymphomoidLevel_CellTypeProportions_ExclOtherCells_StackedBarplot")
-p = plot_ProlifVsNot(markers = all_markerz[all_markerz!="otherCell"], ldf = ldf, OutFileRoot = "LymphomoidLevel_ProlifVsNot_")
-
-## Creating and saving log table
+p = plot_CellTypeProportions(markers = cell_type_markerz, ldf = ldf, OutFileRoot = "LymphomoidLevel_CellTypeProportions_StackedBarplot")
+p = plot_CellTypeProportions(markers = cell_type_markerz[cell_type_markerz!="otherCell"], ldf = ldf, OutFileRoot = "LymphomoidLevel_CellTypeProportions_ExclOtherCells_StackedBarplot")
+p = plot_NonCellTypeMarker(
+   cell_type_markers = cell_type_markerz[cell_type_markerz!="otherCell"], 
+   non_cell_type_markers = other_markerz[other_markerz != "DAPI"],
+   ldf = ldf, 
+   OutFileRoot = "LymphomoidLevel_MarkerStatus_"
+)
+# ## Creating and saving log table
 logdf = data.frame(
    MainDir = MainDir,
    ConfigTable = ConfigTable,

--- a/ClassifyCells_Analyses.R
+++ b/ClassifyCells_Analyses.R
@@ -1,7 +1,7 @@
 
 ########## Input ##########
-MainDir = "/mnt/ndata/varrone/Packages/Lymphomoid-IF-pipeline/output_example/" # Absolute path to your main directory
-ConfigTable = "/mnt/ndata/varrone/Packages/Lymphomoid-IF-pipeline/human_channels.txt" # Configuration table as 'mouse_channels.txt' or 'human_channels.txt' 
+MainDir = "/mnt/ndata/daniele/elisa_lymphomoids/Processed/Pipeline_test/" # Absolute path to your main directory
+ConfigTable = "/mnt/ndata/daniele/elisa_lymphomoids/Lymphomoid-IF-pipeline/mouse_channels.txt" # Configuration table as 'mouse_channels.txt' or 'human_channels.txt' 
 Lymphomoids_to_process = "all" # "all", or vector of boundary file names (e.g. Lymphomoids_to_process = c( "HLS01_s02_acq03_Pembroluzimab01_Boundary.txt", "HLS01_s02_acq03_Pembroluzimab02_Boundary.txt" ) )
 ###########################
 
@@ -180,7 +180,7 @@ plot_NonCellTypeMarker = function(cell_type_markers, non_cell_type_markers, ldf,
          
          # Write proportions to output file
          write.table(cdf, 
-                    file = paste0(MainDir, OutFileRoot, gsub("/","-",cell_marker), "_", other_marker, ".txt"), 
+                    file = paste0(MainDir, OutFileRoot, gsub("/","-",cell_marker), "_", gsub("/","-",other_marker), ".txt"), 
                     quote = F, col.names = T, row.names = T, sep = "\t")
          
          # Reshape data for plotting
@@ -197,7 +197,7 @@ plot_NonCellTypeMarker = function(cell_type_markers, non_cell_type_markers, ldf,
          cdf$TotalCells = paste0("N=", round(cdf$TotalCells))
          
          # Create stacked bar plot
-         pdf(paste0(MainDir, OutFileRoot, gsub("/","-",cell_marker), "_", other_marker, ".pdf"), 
+         pdf(paste0(MainDir, OutFileRoot, gsub("/","-",cell_marker), "_", gsub("/","-",other_marker), ".pdf"), 
              2*nrow(ldf), 6)
          
          p = ggplot(data=cdf, aes(x=Sample, y=value, fill=variable)) +
@@ -311,7 +311,7 @@ for (ll in Lymphomoids_to_process)
       for (marker in other_markerz)
       {
          if (marker != "DAPI") {
-            fileName = paste0(MainDir,"Digital_IF_images/","IFimage_",ImageName,"_",PatientLymphomoidName,"_NoOtherCells_OnlyInLymphomoid_",marker,".pdf")
+            fileName = paste0(MainDir,"Digital_IF_images/","IFimage_",ImageName,"_",PatientLymphomoidName,"_NoOtherCells_OnlyInLymphomoid_",gsub("/","-",marker),".pdf")
             p = plot_digital_image(fileName, quant, plp_df, withOtherCells = F, onlyInLymphomoid = T, nonCellTypeMarker = marker)
          }
       }
@@ -354,11 +354,12 @@ for (ll in Lymphomoids_to_process)
      # Add columns for each combination to the ttdf data frame
      for (i in 1:nrow(combinations)) {
        combination = combinations[i, ]
+       names(combination) = colnames(combinations) # necessary when there is only one marker
        combination_name = paste0(cell_type_marker, "_", paste0(names(combination), ifelse(combination, "+", "-"), collapse = "_"))
        
        # Count cells matching the combination, treating NA as FALSE
        ttdf[, combination_name] = sum(quant$CellType_antibody == cell_type_marker & 
-         apply(quant[, paste0(marker_names, "+")], 1, function(row) {
+         apply(as.data.frame(quant[, paste0(marker_names, "+")]), 1, function(row) { # as.data.frame handles the case in which there is only one marker (which would be otherwise interpreted as vector)
            all(ifelse(is.na(row), FALSE, row) == combination)
          }))
      }

--- a/NeighbourhoodAnalyses.py
+++ b/NeighbourhoodAnalyses.py
@@ -25,7 +25,7 @@ args = parser.parse_args()
 
 this_palette = {"Bcells":"#00EE00","otherCell":"gray","Macrophages":"#EE00EE","CD4":"#FFD700","CD8":"#00CDCD"}
 
-if args.lymphomoids_to_process[0]=='all':
+if args.lymphomoids_to_process=='all':
     lymphomoids_to_process = os.listdir(args.main_dir+'Classified_cells_tables')
     lymphomoids_to_process = np.unique([x[6:len(x)-13] for x in lymphomoids_to_process if x.startswith("Table")])
 else:

--- a/NeighbourhoodAnalyses.py
+++ b/NeighbourhoodAnalyses.py
@@ -15,9 +15,9 @@ warnings.filterwarnings("ignore")
 ## Parsing arguments
 parser = argparse.ArgumentParser()
 parser.add_argument('--main_dir', type=str, required=True) # Absolute path to your main directory
+parser.add_argument('--channel_info_path', type=str, required=True) # Configuration table as 'mouse_channels.txt' or 'human_channels.txt'
 parser.add_argument('--lymphomoids_to_process', type=str, nargs='+', default='all') # Can be 'all' or any space-separated list of lympomoid acquisitions under the folder 'Classified_cells_tables/', e.g. HLS09_s01_acq01_Ibrutinib01 HLS09_s01_acq01_Ibrutinib01
 parser.add_argument('--celltype_query', type=str, default='Bcells') # Can be 'Bcells' (default), 'CD4', 'CD8' or 'Macrophages'
-parser.add_argument('--celltype_query_proliferation_status', type=str, default='any') # Can be 'any' (default, all cells), 'proliferating', or 'not_proliferating'
 parser.add_argument('--consider_othercells', type=str, default='False') # Whether or not to consider unassigned otherCells in the neighbourhood computation
 parser.add_argument('--plot_delaunay', type=str, default='True') # Whether or not to plot the network
 parser.add_argument('--custom_file_prefix', type=str, default='') # Custom file prefix for output (in case you run multiple times wih)
@@ -45,189 +45,212 @@ else:
 dist_df_all = nei_df_all.copy()
 df_all = pd.DataFrame(columns=[ "CellType_marker","ll" ])
 
-for ll in lymphomoids_to_process:
-    print("\n")
-    print("------ Processing ", ll," ------")
-    # Reading and preprocessing table
-    df = pd.read_table( args.main_dir+'Classified_cells_tables/Table_'+ll+'_AllCells.txt' )
-    # df = pd.read_table( '/mnt/ndata/daniele/elisa_lymphomoids/Processed/Pipeline_test/Classified_cells_tables/Table_'+ll+'_AllCells.txt' )
-    
-    if not consider_othercells:
-        df = df.loc[df.CellType_marker != "otherCell",:]
-    df.CellType_marker = df.CellType_marker.str.replace(" ","")
-    df.CellType_marker = df.CellType_marker.str.replace("Tcells","")
-    if (np.sum(df.CellType_marker==args.celltype_query)<5):
-        print("Skipping", ll,", less than 5 query",args.celltype_query)
-        continue
-    adata = anndata.AnnData(df.iloc[:,3:7],obsm={"spatial": np.array(df.iloc[:,7:9])},dtype=np.float32)
-    adata.obs['CellType_color'] = df.CellType_color.values
-    adata.obs['CellType_marker'] = df.CellType_marker.values
-    adata.obs['is_proliferating'] = df.is_proliferating.values
-    sq.gr.spatial_neighbors(adata,coord_type='generic',delaunay=True)
-    plt.style.use('dark_background')
-    if plot_delaunay:
-        sc.pl.spatial(adata, neighbors_key="spatial_neighbors", spot_size=5, color='CellType_marker', palette=this_palette, edges=True, edges_width=0.05, edges_color='#EBEBEB', show=False)
-        plt.savefig(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+ll+'_delaunay_plot_beforeFiltering.pdf')
-    conns, dists = adata.obsp["spatial_connectivities"], adata.obsp["spatial_distances"]
-    distance_percentile = 95.0
-    threshold = np.percentile(np.array(dists[dists != 0]).squeeze(), distance_percentile)
-    conns[dists > threshold] = 0
-    dists[dists > threshold] = 0
-    conns.eliminate_zeros()
-    dists.eliminate_zeros()
-    adata.obs['is_boundary'] = "no"
-    cells_boundary = adata.obs.loc[adata.obsp['spatial_connectivities'].sum(axis=1)<4,].index
-    adata.obs.loc[cells_boundary,'is_boundary'] = "yes"
-    if plot_delaunay:
-        sc.pl.spatial(adata, neighbors_key="spatial_neighbors", spot_size=5, color='CellType_marker', palette=this_palette, edges=True, edges_width=0.05, edges_color='#EBEBEB', show=False)
-        plt.tight_layout()
-        plt.savefig(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+ll+'_delaunay_plot_afterFiltering.pdf')
-        sc.pl.spatial(adata, neighbors_key="spatial_neighbors", spot_size=5, color='is_boundary', palette={"yes":"red","no":"#EBEBEB"}, edges=True, edges_width=0.05, edges_color='#EBEBEB', show=False)
-        plt.tight_layout()
-        plt.savefig(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+ll+'_delaunay_plot_Boundary.pdf')
-    if args.celltype_query_proliferation_status=="proliferating":
-        query_cells = adata.obs.loc[(adata.obs['CellType_marker']==args.celltype_query) & (adata.obs['is_proliferating']),].index
-        title_neighComp = ll+",\nneighbourhood of proliferating "+args.celltype_query
-    elif (args.celltype_query_proliferation_status=="not_proliferating"):
-        query_cells = adata.obs.loc[(adata.obs['CellType_marker']==args.celltype_query) & (~adata.obs['is_proliferating']),].index
-        title_neighComp = ll+",\nneighbourhood of non proliferating "+args.celltype_query
-    else:
-        query_cells = adata.obs.loc[(adata.obs['CellType_marker']==args.celltype_query),].index
-        title_neighComp = ll+",\nneighbourhood of "+args.celltype_query
-    query_cells = pd.Index(list(set(query_cells)-set(cells_boundary)))
-    if (len(query_cells)<5):
-        print("Skipping", ll,", less than 5 query",args.celltype_query,"after subsetting for proliferation status")
-        continue
-    if consider_othercells:
-        nei_df = pd.DataFrame(np.NaN,query_cells,[ "Bcells","CD4","CD8","Macrophages","otherCell" ])
-        this_df = df.loc[:,["CellType_marker","is_proliferating"] ]
-        this_df['ll'] = ll
-        this_df = this_df.drop(columns="is_proliferating")
-        df_all = pd.concat([df_all,this_df],axis=0)
-    else:
-        nei_df = pd.DataFrame(np.NaN,query_cells,[ "Bcells","CD4","CD8","Macrophages" ])
-        this_df = df.loc[df.CellType_marker!="otherCell",["CellType_marker","is_proliferating"] ]
-        this_df['ll'] = ll
-        this_df = this_df.drop(columns="is_proliferating")
-        df_all = pd.concat([df_all,this_df],axis=0)
-    dist_df = nei_df.copy()
+config_table = pd.read_table(args.channel_info_path)
+non_cell_type_markers = list(config_table[(config_table['Is_CellType_Marker'] == False) & (config_table['Antibody'] != 'DAPI')]['Antibody'].values)
+for marker in [''] + [f'{m}+' for m in non_cell_type_markers]:
+    nei_df_all = None
+    dist_df_all = None
+    df_all = None
 
-    query_spatial_conn = adata.obsp['spatial_connectivities'][:,:].toarray()
-    query_spatial_dist = adata.obsp['spatial_distances'][:,:].toarray()
-    for q in tqdm(query_cells):
-        nei = adata.obs.loc[query_spatial_conn[:,adata.obs_names==q]==1,].copy()
-        dist = query_spatial_dist[ adata.obs_names.isin(nei.index) ,adata.obs_names==q]
-        nei['distance'] = dist
-        nei = nei.loc[:,[ "CellType_marker","distance" ]]
-        tabb = nei.CellType_marker.value_counts()/nei.shape[0]
-        nei_df.loc[q,tabb.index.tolist()] = tabb.tolist()
-        tabb = nei.groupby(['CellType_marker']).mean()
-        dist_df.loc[q,tabb.index.tolist()] = tabb['distance']
+    for ll in lymphomoids_to_process:
+        print("\n")
+        print("------ Processing ", ll," ------")
+        # Reading and preprocessing table
+        df = pd.read_table( args.main_dir+'Classified_cells_tables/Table_'+ll+'_AllCells.txt' )
+        # df = pd.read_table( '/mnt/ndata/daniele/elisa_lymphomoids/Processed/Pipeline_test/Classified_cells_tables/Table_'+ll+'_AllCells.txt' )
+
+        if not consider_othercells:
+            df = df.loc[df.CellType_marker != "otherCell",:]
+        df.CellType_marker = df.CellType_marker.str.replace(" ","")
+        df.CellType_marker = df.CellType_marker.str.replace("Tcells","")
+        if (np.sum(df.CellType_marker==args.celltype_query)<5):
+            print("Skipping", ll,", less than 5 query",args.celltype_query)
+            continue
+        adata = anndata.AnnData(df.iloc[:,3:7],obsm={"spatial": np.array(df.iloc[:,7:9])},dtype=np.float32)
+        adata.obs['CellType_color'] = df.CellType_color.values
+        adata.obs['CellType_marker'] = df.CellType_marker.values
+
+        sq.gr.spatial_neighbors(adata,coord_type='generic',delaunay=True)
+        plt.style.use('dark_background')
+        if plot_delaunay:
+            sc.pl.spatial(adata, neighbors_key="spatial_neighbors", spot_size=5, color='CellType_marker', palette=this_palette, edges=True, edges_width=0.05, edges_color='#EBEBEB', show=False)
+            plt.savefig(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+ll+'_delaunay_plot_beforeFiltering.pdf')
+        conns, dists = adata.obsp["spatial_connectivities"], adata.obsp["spatial_distances"]
+        distance_percentile = 95.0
+        threshold = np.percentile(np.array(dists[dists != 0]).squeeze(), distance_percentile)
+        conns[dists > threshold] = 0
+        dists[dists > threshold] = 0
+        conns.eliminate_zeros()
+        dists.eliminate_zeros()
+        adata.obs['is_boundary'] = "no"
+        cells_boundary = adata.obs.loc[adata.obsp['spatial_connectivities'].sum(axis=1)<4,].index
+        adata.obs.loc[cells_boundary,'is_boundary'] = "yes"
+        if plot_delaunay:
+            sc.pl.spatial(adata, neighbors_key="spatial_neighbors", spot_size=5, color='CellType_marker', palette=this_palette, edges=True, edges_width=0.05, edges_color='#EBEBEB', show=False)
+            plt.tight_layout()
+            plt.savefig(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+ll+'_delaunay_plot_afterFiltering.pdf')
+            sc.pl.spatial(adata, neighbors_key="spatial_neighbors", spot_size=5, color='is_boundary', palette={"yes":"red","no":"#EBEBEB"}, edges=True, edges_width=0.05, edges_color='#EBEBEB', show=False)
+            plt.tight_layout()
+            plt.savefig(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+ll+'_delaunay_plot_Boundary.pdf')
+        # if args.celltype_query_non_cell_type_markers[0] == "any":
+        
+        # else:
+        #     non_cell_type_markers = args.celltype_query_non_cell_type_markers
+
+        
+        
+        adata.obs[[f'{m}+' for m in non_cell_type_markers]] = df[[f'{m}+' for m in non_cell_type_markers]].values
+        # ToDo: REMOVE!
+        pos_bcells = adata[(adata.obs['CellType_marker'] == 'Bcells')].obs.sample(100, replace=False) 
+        adata.obs.loc[pos_bcells.index, 'Ki67+'] = True
+    
+        # marker = ([''] + [f'{m}+' for m in non_cell_type_markers])[0]
+        print('marker:', marker)
+        if marker == '':
+            query_cells = adata.obs.loc[(adata.obs['CellType_marker']==args.celltype_query),].index
+        else:
+            query_cells = adata.obs.loc[(adata.obs['CellType_marker']==args.celltype_query) & adata.obs[marker],].index
+        title_neighComp = ll+",\nneighbourhood of "+args.celltype_query+" "+marker
+
+        query_cells = pd.Index(list(set(query_cells)-set(cells_boundary)))
+        if (len(query_cells)<5):
+            print("Skipping", ll,", less than 5 query",args.celltype_query,"after subsetting for "+marker+" status")
+            continue
+
+        if consider_othercells:
+            cell_types = ["Bcells","CD4","CD8","Macrophages","otherCell"]
+        else:
+            cell_types = ["Bcells","CD4","CD8","Macrophages"]
+
+        nei_df = pd.DataFrame(np.NaN,query_cells,cell_types)
+        this_df = df.loc[df.CellType_marker.isin(cell_types), ["CellType_marker"] ]
+        this_df['ll'] = ll
+        # this_df = this_df.drop(columns=f"{marker}+")
+        df_all = pd.concat([df_all,this_df],axis=0)
+        dist_df = nei_df.copy()
+
+        query_spatial_conn = adata.obsp['spatial_connectivities'][:,:].toarray()
+        query_spatial_dist = adata.obsp['spatial_distances'][:,:].toarray()
+        for q in tqdm(query_cells):
+            nei = adata.obs.loc[query_spatial_conn[:,adata.obs_names==q]==1,].copy()
+            dist = query_spatial_dist[ adata.obs_names.isin(nei.index) ,adata.obs_names==q]
+            nei['distance'] = dist
+            nei = nei.loc[:,[ "CellType_marker","distance" ]]
+            tabb = nei.CellType_marker.value_counts()/nei.shape[0]
+            nei_df.loc[q,tabb.index.tolist()] = tabb.tolist()
+            tabb = nei.groupby(['CellType_marker']).mean()
+            dist_df.loc[q,tabb.index.tolist()] = tabb['distance']
+
+        # Plotting neigh composition
+        nei_df_melt = pd.melt(nei_df)
+        nei_df_melt.columns = [ "Neighbouring cell type","Relative frequency" ]
+        plt.style.use('classic')
+        plt.figure()
+        sns.barplot(data=nei_df_melt, x="Neighbouring cell type", y="Relative frequency", palette=this_palette)
+        plt.ylim(0, 1)
+        plt.title( title_neighComp )
+        plt.tight_layout()
+        plt.savefig(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+ll+'_'+args.celltype_query+'_'+marker+'_NeighbourhoodFrequencies.pdf')
+        plt.close()
+        nei_df.to_csv(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+ll+'_'+args.celltype_query+'_'+marker+'_NeighbourhoodFrequencies_FullTable.csv')
+
+        # Plotting distance density distributions
+        dist_df_melt = pd.melt(dist_df)
+        dist_df_melt = dist_df_melt.dropna()
+        dist_df_melt.columns = [ "Neighbouring cell type","Distance (µm)" ]
+        plt.figure()
+        sns.kdeplot(data=dist_df_melt, hue="Neighbouring cell type", x="Distance (µm)",linewidth=2, palette=this_palette)
+        plt.tight_layout()
+        plt.savefig(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+ll+'_'+args.celltype_query+'_'+marker+'_DistanceDistributions.pdf')
+        plt.close()
+        dist_df.to_csv(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+ll+'_'+args.celltype_query+'_'+marker+'_DistanceDistributions_FullTable.csv')
+
+        # # Concatenating into full dataframes
+        nei_df['ll'] = ll
+        dist_df['ll'] = ll
+        nei_df_all = pd.concat([nei_df_all,nei_df],axis=0)
+        dist_df_all = pd.concat([dist_df_all,dist_df],axis=0)
+# ### END IF
+
+    if nei_df_all is None:
+        continue
+
+    
+
+    ## Second, collapse lymphomoids
+    nei_df_all['PatientLymphomoidName'] = [thisll[::-1].partition('_')[0][::-1] for thisll in nei_df_all['ll']]
+    dist_df_all['PatientLymphomoidName'] = [thisll[::-1].partition('_')[0][::-1] for thisll in dist_df_all['ll']]
+    df_all['PatientLymphomoidName'] = [thisll[::-1].partition('_')[0][::-1] for thisll in df_all['ll']]
+    nei_df_all.to_csv(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+'AllLymphomoids_'+args.celltype_query+'_'+marker+'_NeighbourhoodFrequencies_FullTable.csv')
+    dist_df_all.to_csv(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+'AllLymphomoids_'+args.celltype_query+'_'+marker+'_DistanceDistributions_FullTable.csv')
+
+    # nei_df_all = pd.read_csv( "/mnt/ndata/daniele/elisa_lymphomoids/Processed/Pipeline_test/Neighbourhood_analyses/LP08Any_AllLymphomoids_NeighbourhoodFrequencies_FullTable.csv" )
+    nei_df_all.loc[nei_df_all.Bcells.isna(),"Bcells"] = 0
+    nei_df_all.loc[nei_df_all.CD4.isna(),"CD4"] = 0
+    nei_df_all.loc[nei_df_all.CD8.isna(),"CD8"] = 0
+    nei_df_all.loc[nei_df_all.Macrophages.isna(),"Macrophages"] = 0
+    # nei_df_all = nei_df_all.loc[nei_df_all.ll.isin(df_all.ll.unique()),]
 
     # Plotting neigh composition
-    nei_df_melt = pd.melt(nei_df)
-    nei_df_melt.columns = [ "Neighbouring cell type","Relative frequency" ]
+    nei_df_all = nei_df_all.drop(columns="ll")
+    df_all = df_all.drop( columns = 'll' )
+    # nei_df_all = nei_df_all.drop(columns="Unnamed: 0")
+    dist_df_all = dist_df_all.drop(columns="ll")
+
+    nei_df_grouped = nei_df_all.groupby(['PatientLymphomoidName']).mean()
+    # nei_df_grouped.sum(1)
+
+    # Obs vs Exp
+    df_all_grouped = nei_df_grouped.copy()
+    for i in df_all_grouped.index:
+        for j in df_all_grouped.columns:
+            df_all_grouped.loc[i,j] = np.sum((df_all.CellType_marker==j) & (df_all.PatientLymphomoidName==i) )
+    df_all_grouped = df_all_grouped.div(df_all_grouped.sum(1),axis=0)
+    obs_vs_exp_log_ratio = np.log2(nei_df_grouped/df_all_grouped)
+    obs_vs_exp_log_ratio['PatientLymphomoidName'] = obs_vs_exp_log_ratio.index
+    oe = pd.melt(obs_vs_exp_log_ratio,'PatientLymphomoidName')
+    oe.columns = ["PatientLymphomoidName", "CellType","Obs_vs_Exp_log2_ratio" ]
     plt.style.use('classic')
     plt.figure()
-    sns.barplot(data=nei_df_melt, x="Neighbouring cell type", y="Relative frequency", palette=this_palette)
-    plt.ylim(0, 1)
-    plt.title( title_neighComp )
+    sns.barplot(data=oe, x="PatientLymphomoidName", y="Obs_vs_Exp_log2_ratio", hue="CellType", palette=this_palette)
+    plt.xticks(rotation=45)
     plt.tight_layout()
-    plt.savefig(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+ll+'_NeighbourhoodFrequencies.pdf')
+    plt.savefig(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+args.celltype_query+'_'+marker+'_Obs_vs_Exp_log2_ratio.pdf')
     plt.close()
-    nei_df.to_csv(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+ll+'_NeighbourhoodFrequencies_FullTable.csv')
+    oe.to_csv(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+'AllLymphomoids_'+args.celltype_query+'_'+marker+'_Obs_vs_Exp_log2_ratio_Table.csv')
 
-    # Plotting distance density distributions
-    dist_df_melt = pd.melt(dist_df)
-    dist_df_melt = dist_df_melt.dropna()
-    dist_df_melt.columns = [ "Neighbouring cell type","Distance (µm)" ]
+    # Barplot overall
+    nei_df_grouped['PatientLymphomoidName'] = nei_df_grouped.index.values
+    plt.style.use('classic')
     plt.figure()
-    sns.kdeplot(data=dist_df_melt, hue="Neighbouring cell type", x="Distance (µm)",linewidth=2, palette=this_palette)
+    fig, ax = plt.subplots()
+    groups = nei_df_grouped['PatientLymphomoidName'].values.tolist()
+    values_Bcells = nei_df_grouped['Bcells'].values.tolist()
+    values_CD4 = nei_df_grouped['CD4'].values.tolist()
+    values_CD8 = nei_df_grouped['CD8'].values.tolist()
+    values_Macrophages = nei_df_grouped['Macrophages'].values.tolist()
+    ax.bar(groups, values_Bcells, color = "#00EE00", edgecolor = "black", linewidth = 1,label='Bcells')
+    ax.bar(groups, values_CD4, bottom = values_Bcells, color = "#FFD700", edgecolor = "black", linewidth = 1,label='CD4')
+    ax.bar(groups, values_CD8, bottom = np.add(values_Bcells,values_CD4), color = "#00CDCD", edgecolor = "black", linewidth = 1,label='CD8')
+    ax.bar(groups, values_Macrophages, bottom = np.add(np.add(values_Bcells,values_CD4),values_CD8), color = "#EE00EE", edgecolor = "black", linewidth = 1,label='Macrophages')
+    if consider_othercells:
+        values_otherCell = nei_df_grouped['otherCell'].values.tolist()
+        ax.bar(groups, values_otherCell, bottom = np.add(np.add(np.add(values_Bcells,values_CD4),values_CD8),values_Macrophages), color = "gray", edgecolor = "black", linewidth = 1,label='otherCell')
+    ax.legend(loc='lower right')
+    plt.xticks(rotation=45)
+    plt.ylabel('Relative frequency' )
     plt.tight_layout()
-    plt.savefig(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+ll+'_DistanceDistributions.pdf')
+    # plt.savefig("/mnt/ndata/daniele/elisa_lymphomoids/Processed/Pipeline_test/Neighbourhood_analyses/LP08Any_AllLymphomoids_NeighbourhoodFrequencies_temp.pdf" )
+    plt.savefig(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+'AllLymphomoids_'+args.celltype_query+'_'+marker+'_NeighbourhoodFrequencies.pdf')
     plt.close()
-    dist_df.to_csv(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+ll+'_DistanceDistributions_FullTable.csv')
 
-    # Concatenating into full dataframes
-    nei_df['ll'] = ll
-    dist_df['ll'] = ll
-    nei_df_all = pd.concat([nei_df_all,nei_df],axis=0)
-    dist_df_all = pd.concat([dist_df_all,dist_df],axis=0)
-
-## Second, collapse lymphomoids
-nei_df_all['PatientLymphomoidName'] = [thisll[::-1].partition('_')[0][::-1] for thisll in nei_df_all['ll']]
-dist_df_all['PatientLymphomoidName'] = [thisll[::-1].partition('_')[0][::-1] for thisll in dist_df_all['ll']]
-df_all['PatientLymphomoidName'] = [thisll[::-1].partition('_')[0][::-1] for thisll in df_all['ll']]
-nei_df_all.to_csv(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+'AllLymphomoids_NeighbourhoodFrequencies_FullTable.csv')
-dist_df_all.to_csv(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+'AllLymphomoids_DistanceDistributions_FullTable.csv')
-
-# nei_df_all = pd.read_csv( "/mnt/ndata/daniele/elisa_lymphomoids/Processed/Pipeline_test/Neighbourhood_analyses/LP08Any_AllLymphomoids_NeighbourhoodFrequencies_FullTable.csv" )
-nei_df_all.loc[nei_df_all.Bcells.isna(),"Bcells"] = 0
-nei_df_all.loc[nei_df_all.CD4.isna(),"CD4"] = 0
-nei_df_all.loc[nei_df_all.CD8.isna(),"CD8"] = 0
-nei_df_all.loc[nei_df_all.Macrophages.isna(),"Macrophages"] = 0
-# nei_df_all = nei_df_all.loc[nei_df_all.ll.isin(df_all.ll.unique()),]
-
-# Plotting neigh composition
-nei_df_all = nei_df_all.drop(columns="ll")
-df_all = df_all.drop( columns = 'll' )
-# nei_df_all = nei_df_all.drop(columns="Unnamed: 0")
-dist_df_all = dist_df_all.drop(columns="ll")
-
-nei_df_grouped = nei_df_all.groupby(['PatientLymphomoidName']).mean()
-# nei_df_grouped.sum(1)
-
-# Obs vs Exp
-df_all_grouped = nei_df_grouped.copy()
-for i in df_all_grouped.index:
-    for j in df_all_grouped.columns:
-        df_all_grouped.loc[i,j] = np.sum((df_all.CellType_marker==j) & (df_all.PatientLymphomoidName==i) )
-df_all_grouped = df_all_grouped.div(df_all_grouped.sum(1),axis=0)
-obs_vs_exp_log_ratio = np.log2(nei_df_grouped/df_all_grouped)
-obs_vs_exp_log_ratio['PatientLymphomoidName'] = obs_vs_exp_log_ratio.index
-oe = pd.melt(obs_vs_exp_log_ratio,'PatientLymphomoidName')
-oe.columns = ["PatientLymphomoidName", "CellType","Obs_vs_Exp_log2_ratio" ]
-plt.style.use('classic')
-plt.figure()
-sns.barplot(data=oe, x="PatientLymphomoidName", y="Obs_vs_Exp_log2_ratio", hue="CellType", palette=this_palette)
-plt.xticks(rotation=45)
-plt.tight_layout()
-plt.savefig(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+'Obs_vs_Exp_log2_ratio.pdf')
-plt.close()
-oe.to_csv(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+'AllLymphomoids_Obs_vs_Exp_log2_ratio_Table.csv')
-
-# Barplot overall
-nei_df_grouped['PatientLymphomoidName'] = nei_df_grouped.index.values
-plt.style.use('classic')
-plt.figure()
-fig, ax = plt.subplots()
-groups = nei_df_grouped['PatientLymphomoidName'].values.tolist()
-values_Bcells = nei_df_grouped['Bcells'].values.tolist()
-values_CD4 = nei_df_grouped['CD4'].values.tolist()
-values_CD8 = nei_df_grouped['CD8'].values.tolist()
-values_Macrophages = nei_df_grouped['Macrophages'].values.tolist()
-ax.bar(groups, values_Bcells, color = "#00EE00", edgecolor = "black", linewidth = 1,label='Bcells')
-ax.bar(groups, values_CD4, bottom = values_Bcells, color = "#FFD700", edgecolor = "black", linewidth = 1,label='CD4')
-ax.bar(groups, values_CD8, bottom = np.add(values_Bcells,values_CD4), color = "#00CDCD", edgecolor = "black", linewidth = 1,label='CD8')
-ax.bar(groups, values_Macrophages, bottom = np.add(np.add(values_Bcells,values_CD4),values_CD8), color = "#EE00EE", edgecolor = "black", linewidth = 1,label='Macrophages')
-if consider_othercells:
-    values_otherCell = nei_df_grouped['otherCell'].values.tolist()
-    ax.bar(groups, values_otherCell, bottom = np.add(np.add(np.add(values_Bcells,values_CD4),values_CD8),values_Macrophages), color = "gray", edgecolor = "black", linewidth = 1,label='otherCell')
-ax.legend(loc='lower right')
-plt.xticks(rotation=45)
-plt.ylabel('Relative frequency' )
-plt.tight_layout()
-# plt.savefig("/mnt/ndata/daniele/elisa_lymphomoids/Processed/Pipeline_test/Neighbourhood_analyses/LP08Any_AllLymphomoids_NeighbourhoodFrequencies_temp.pdf" )
-plt.savefig(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+'AllLymphomoids_NeighbourhoodFrequencies.pdf')
-plt.close()
-
-for col in list(set(['Bcells','CD4','CD8','Macrophages','otherCell']) & set(dist_df_all.columns.values.tolist())):
-    this_dist_df_all = dist_df_all.loc[:,[col,"PatientLymphomoidName"]].copy().dropna()
-    plt.figure()
-    sns.kdeplot(data=this_dist_df_all, hue='PatientLymphomoidName', x=col,linewidth=2,palette="Set2")
-    plt.tight_layout()
-    plt.savefig(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+'AllLymphomoids_'+col+'_DistanceDistributions.pdf')
-    plt.close() 
+    for col in list(set(['Bcells','CD4','CD8','Macrophages','otherCell']) & set(dist_df_all.columns.values.tolist())):
+        this_dist_df_all = dist_df_all.loc[:,[col,"PatientLymphomoidName"]].copy().dropna()
+        plt.figure()
+        sns.kdeplot(data=this_dist_df_all, hue='PatientLymphomoidName', x=col,linewidth=2,palette="Set2")
+        plt.tight_layout()
+        plt.savefig(args.main_dir+'/Neighbourhood_analyses/'+args.custom_file_prefix+'AllLymphomoids_'+args.celltype_query+'_'+marker+'_'+col+'_DistanceDistributions.pdf')
+        plt.close() 
 
 
 

--- a/README.md
+++ b/README.md
@@ -202,15 +202,15 @@ Here we take the tables with classified cells under `Classified_cells_tables/` a
 
 The input of _NeighbourhoodAnalyses.py_ is the following:
 * `--main_dir`: your main directory, same as for the previous steps
+* `--channel_info_path`: the path to the .txt or .tsv file containing information on the image channels. The values must be separated by tabs. In particular, the file must contain a _Channel\_name_ and a _Cellular\_location_ (Nucleus or Cytoplasm) column.
 * `--lymphomoids_to_process`: set to _all_ if you want all lymphomoids saved under `Classified_cells_tables/` to be processed, otherwise specify a subset of them as a character list (default: _all_)
 * `--celltype_query`: the cell type of which you want to compute the analyse the neighbourhood (default: Bcells)
-* `--celltype_query_proliferation_status`: whether to consider _any_ of the query cells, only _proliferating_ or only _not_proliferating_ (it solely accepts these three values, default: _any_)
 * `--consider_othercells`: whether to consider unclassified otherCells in the neighbourhood composition (default: False)
 * `--plot_delaunay`: whether to plot the spatial Delaunay networks (default: True)
 * `--custom_file_prefix`: optional prefix to add to the output files
 
 An example of script call is:
-`python NeighbourhoodAnalyses.py --main_dir /mnt/ndata/daniele/elisa_lymphomoids/Processed/Pipeline_test/ --lymphomoids_to_process all --celltype_query Bcells --celltype_query_proliferation_status any --consider_othercells False --plot_delaunay True --custom_file_prefix Test24Apr_`
+`python NeighbourhoodAnalyses.py --main_dir /mnt/ndata/daniele/elisa_lymphomoids/Processed/Pipeline_test/ --channel_info_path /mnt/data2/varrone/elisa_lymphomoids/mouse_channels.txt --lymphomoids_to_process all --celltype_query Bcells --consider_othercells False --plot_delaunay True --custom_file_prefix Test24Apr_`
 
 Output files (plots and tables with query cell-level neighbourhood composition and distances) are saved in the newly created `Neighbourhood_analyses/` under MainDir.
 
@@ -218,5 +218,9 @@ Nearest neighbours that are farther than the 95th percentile of physical distanc
 
 Since all tables are saved, you can customize your plots/perfom additional downstream analyses by reading them back in your favourite programming language.
 
-
-
+# CHANGELOG
+- 22Nov2024: It's possible to define non-cell-type markers in the configuration talbe. Those markers will not be used for cell type classification, but their intensity will be used to divide cells into positive or negative for that marker. This is a generalization of the previous implementation, that was specific for Ki67 (proliferation marker).
+   - The configuration tables must contain a new column called `Is_CellType_Marker` that can be either `TRUE` or `FALSE`.
+   - The plots will not include `proliferating` vs `not proliferating`, but `marker+` vs `marker-`. The old proliferating cells are now `Ki67+`.
+   - Neighborhood analyses does not require the `--celltype_query_proliferation_status` parameter anymore, but requires the the path to the configuration table using the parameter `--channel_info_path`.
+   - Neighborhood analyses outputs plots and tables for cells negative for all markers, but also for cells positive for each marker individually. The file names also include the query cell type.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ This step, except the part of format conversion, is fairly automatized, so it is
 
 DeepCell is a nuclei and cell segmentation software that is more robust to different levels of marker intensity and, thus, gives better results when the intensity of DAPI varies dramatically in the same sample.
 
-
 The script run in Step 2 should have already created, inside the main directory, a directory called _Quantification_. _Quantification_ contains other directories with the _ImageName_ for which boundaries have been drawn and finally, each of this directory should contain an empty directory called _registration_.
 
 To summarize, you should find a structure like the following:
@@ -75,12 +74,25 @@ Quantification
 ...
 ```
 
-### VSI to .OME.TIF format conversion
-In this step we will convert the images from the .vsi to the .ome.tif format. The script uses a software called _bfconvert_ from Bio-Formats Tools, and requires the packages listed in the file _requirements.txt_. In order to install them, make sure that you are using Python 3 (version 3.8 or newer), and if you are using a conda environment, run `conda install -c conda-forge pip openjdk`. Then, run `pip install numpy`, then `pip install -r requirements.txt` and finally `pip install numpy --upgrade`.
 
-1. If it doesn't already exist, create a directory called _Tiff_ inside the main directory. So it should be at the same level of the _Quantification_ directory.
-2. Connect to the server using ssh on your Terminal and move to the directory containing the scripts of the pipeline.
-3. Run the script _vsi2tiff.py_ with the following required parameters:
+### Conda environment (one-time setup)
+The scripts in this step require some packages that need to be installed in a Conda environment.
+
+If you don't have a Conda environment, you can create one by running `conda create -n lymphomoid_if conda-forge::python=3.9`.
+
+In order to install the packages listed in the file _requirements.txt_, run `conda install -c conda-forge openjdk gcc singularity python-javabridge ome::bftools bioconda::nextflow=21.10.6`. Then `pip install -r requirements.txt`.
+
+This step must be done only once. The next time you need to use the pipeline, you can activate the environment with `conda activate lymphomoid_if`.
+
+
+
+### VSI to .OME.TIF format conversion
+In this step we will convert the images from the .vsi to the .ome.tif format. The script uses a software called _bfconvert_ from Bio-Formats Tools.
+
+1. If not yet activated, activate the environment using `conda activate lymphomoid_if`.
+2. If it doesn't already exist, create a directory called _Tiff_ inside the main directory. So it should be at the same level of the _Quantification_ directory.
+3. Connect to the server using ssh on your Terminal and move to the directory containing the scripts of the pipeline.
+4. Run the script _vsi2tiff.py_ with the following required parameters:
    * `--input_vsi`: the path to the .vsi file that needs to be converted into .ome.tif files.
    * `--output_dir`: the path to the _Tiff_ directory
 
@@ -90,9 +102,9 @@ In this step we will convert the images from the .vsi to the .ome.tif format. Th
    * `--bftools_dir`: the path to the _bftools_ director. The default is `/mnt/data2/shared/Lymphomoid-IF-software/bftools` where it's already present.
 
    </details>
-4. Note that a single vsi will generate a separate .ome.tif file for each image acquisition. The script will create multiple .ome.tif files concatenating the name of the parent directory of the .vsi file, the name of the .vsi file and the acquisition number.
-5. Delete the acquisitions that have been discarded in Step 1. You can identify those acquisitions because there is no equivalent directory inside _Quantification_.
-6. Rename with _ImageName.ome.tif_ and move each image into the _registration_ folder of the corresponding directory. So, every registration folder should contain one and only one .ome.tif file, as in the following diagram:
+5. Note that a single vsi will generate a separate .ome.tif file for each image acquisition. The script will create multiple .ome.tif files concatenating the name of the parent directory of the .vsi file, the name of the .vsi file and the acquisition number.
+6. Delete the acquisitions that have been discarded in Step 1. You can identify those acquisitions because there is no equivalent directory inside _Quantification_.
+7. Rename with _ImageName.ome.tif_ and move each image into the _registration_ folder of the corresponding directory. So, every registration folder should contain one and only one .ome.tif file, as in the following diagram:
    ```bash
    Quantification
    ├── HLS07_s01_acq01
@@ -110,17 +122,9 @@ In this step we will convert the images from the .vsi to the .ome.tif format. Th
 In case you have doubts on to which .vsi file a .ome.tif file corresponds too, you can import the .ome.tif file in QuPath and compare it.
 
 ### Cell detection (i.e. segmentation)
-The cell detection script require few Python packages for basic file processing. They are all already installed as a Python virtual environment in _/mnt/data2/shared/Lymphomoid-IF-software/Lymphomoid-IF-venv/_. 
+1. If the environment is not yet activated, activate it using `conda activate lymphomoid_if`.
 
-If you want to download and install them somewhere else, the required packages are listed in the file _requirements.txt_. 
-
-1. To be able to access the packages you need to activate the environment using:
-
-   `source /mnt/data2/shared/Lymphomoid-IF-software/Lymphomoid-IF-venv/bin/activate`
-
-   or activate your environment if you are using your own personal one.
-
-2. Then you need to run the _cellDetection.py_ script, with the following required parameters:
+2. Run the _cellDetection.py_ script, with the following required parameters:
    * `--sample_names`: a list of _ImageName_ of the images to process, it could be 1 or many, separated by a whitespace (see example later).
    * `--dir`: the path of the _Quantification_ directory
    * `--channel_info_path`: the path to the .txt or .tsv file containing information on the image channels. The values must be separated by tabs. In particular, the file must contain a _Channel\_name_ and a _Cellular\_location_ (Nucleus or Cytoplasm) column.
@@ -142,9 +146,9 @@ The run may take a while for each image (tens of minutes). For this reason, it i
 ### Marker quantification (i.e. segmentation)
 This step obtains for each cell, from its mask detected in the cell detection step, the mean intensities of each of the markers in the nucleus and in the cytoplasm.
 
-1. To run this step, check first that you are part of the Docker group on the server. If your username is in the output of `grep /etc/group -e "docker"`, you can move to the next point, otherwise ask the system admin (currently Luca Nanni) to add you to the Docker group.
-2. If the virtual environment has not been activated from the cell detection part, run the `source /mnt/data2/shared/Lymphomoid-IF-software/Lymphomoid-IF-venv/bin/activate` command to activate the virtual environment.
-3. Then, run the _quantifyIntensities.py_ script, with the same required parameters as in the cell detection step:
+1. To run this step, check first that you are part of the Docker group on the server. If your username is in the output of `grep /etc/group -e "docker"`, you can move to the next point, otherwise ask the system admin (currently Divyanshu Srivastava) to add you to the Docker group.
+2. If the conda environment is not yet activated, activate it using `conda activate lymphomoid_if`.
+3. Run the _quantifyIntensities.py_ script, with the same required parameters as in the cell detection step:
    * `--sample_names`: a list of _ImageName_ of the images to process, it could be 1 or many, separated by a whitespace (see example later).
    * `--dir`: the absolute path of the _Quantification_ directory
    * `--channel_info_path`: the path to the .txt or .tsv file containing information on the image channels. The values must be separated by tabs. In particular, the file must contain a _Channel\_name_ and a _Cellular\_location_ (Nucleus or Cytoplasm) column.
@@ -165,7 +169,7 @@ If you want to download or update the four software required:
 * bftools: bftools can be downloaded from the Bio-Formats [website](https://docs.openmicroscopy.org/bio-formats/6.8.1/users/comlinetools/index.html). Current version: 6.8.1.
 * Virtual Environment: the Python packages required for running the pipeline are listed in the file _requirements.txt_. If you want to install the packages in your current virtual environment, if you are using conda, make sure to run `conda install pip` first. Then you can run `pip install -r requirements.txt`. 
 * DeepCell: the image for Singularity can be downloaded running `singularity pull deepcell.sif docker://vanvalenlab/deepcell-applications:latest`. Current version: 0.3.1.
-* Nextflow: select the directory where ypu want to download nextflow and run `curl -s https://get.nextflow.io | bash`. For more information visit the [website](https://nextflow.io). Current version: 21.10.6.5660.
+* Nextflow: select the directory where you want to download nextflow and run `curl -s https://get.nextflow.io | bash`. For more information visit the [website](https://nextflow.io). Current version: 21.10.6.5660.
 * MCMICRO: you can get the latest version of MCMICRO by moving to the directory where _nextflow_ is (e.g. `/mnt/data2/shared/Lymphomoid-IF-software/nextflow`) and running `./nextflow pull labsyspharm/mcmicro`. For more information visit the [website](https://mcmicro.org). Current version: Github revision 46abd97bc0.
 
 ## Step 5 - Classify cells and downstream analyses

--- a/README.md
+++ b/README.md
@@ -219,8 +219,8 @@ Nearest neighbours that are farther than the 95th percentile of physical distanc
 Since all tables are saved, you can customize your plots/perfom additional downstream analyses by reading them back in your favourite programming language.
 
 # CHANGELOG
-- 22Nov2024: It's possible to define non-cell-type markers in the configuration talbe. Those markers will not be used for cell type classification, but their intensity will be used to divide cells into positive or negative for that marker. This is a generalization of the previous implementation, that was specific for Ki67 (proliferation marker).
+- 22Nov2024: It's possible to define non-cell-type markers in the configuration table. Those markers will not be used for cell type classification, but their intensity will be used to divide cells into positive or negative for that marker. This is a generalization of the previous implementation, that was specific for Ki67 (proliferation marker).
    - The configuration tables must contain a new column called `Is_CellType_Marker` that can be either `TRUE` or `FALSE`.
    - The plots will not include `proliferating` vs `not proliferating`, but `marker+` vs `marker-`. The old proliferating cells are now `Ki67+`.
-   - Neighborhood analyses does not require the `--celltype_query_proliferation_status` parameter anymore, but requires the the path to the configuration table using the parameter `--channel_info_path`.
+   - Neighborhood analyses does not require the `--celltype_query_proliferation_status` parameter anymore, but requires the path to the configuration table using the parameter `--channel_info_path`.
    - Neighborhood analyses outputs plots and tables for cells negative for all markers, but also for cells positive for each marker individually. The file names also include the query cell type.

--- a/human_channels.txt
+++ b/human_channels.txt
@@ -1,7 +1,7 @@
-Channel_name	Cellular_location	Antibody	Marker_of	Fluorochrome	Species
-DAPI	Nucleus	DAPI	Nucleus	DAPI	Human
-FITC	Cytoplasm	CD20	B cells	FAM	Human
-CFP	Cytoplasm	CD4	CD4	DCC	Human
-RFP	Cytoplasm	CD8	CD8	R6G	Human
-CY5	Nucleus	Ki67	Proliferation	Cy5	Human
-Alexa 594	Cytoplasm	CD68	Macrophages	R610	Human
+Channel_name	Cellular_location	Antibody	Marker_of	Fluorochrome	Species	Is_CellType_Marker
+DAPI	Nucleus	DAPI	Nucleus	DAPI	Human	FALSE
+FITC	Cytoplasm	CD20	B cells	FAM	Human	TRUE
+CFP	Cytoplasm	CD4	CD4	DCC	Human	TRUE
+RFP	Cytoplasm	CD8	CD8	R6G	Human	TRUE
+CY5	Nucleus	Ki67	Proliferation	Cy5	Human	FALSE
+Alexa 594	Cytoplasm	CD68	Macrophages	R610	Human	FALSE

--- a/mouse_channels.txt
+++ b/mouse_channels.txt
@@ -1,7 +1,7 @@
-Channel_name	Cellular_location	Antibody	Marker_of	Fluorochrome	Species
-DAPI	Nucleus	DAPI	Nucleus	DAPI	Mouse
-FITC	Cytoplasm	B220	B cells	FAM	Mouse
-CFP	Cytoplasm	CD4	CD4 T cells	DCC	Mouse
-CY5	Cytoplasm	CD8	CD8 T cells	Cy5	Mouse
-Alexa 594	Nucleus	Ki67	Proliferation	R610	Mouse
-RFP	Cytoplasm	F4/80	Macrophages	R6G	Mouse
+Channel_name	Cellular_location	Antibody	Marker_of	Fluorochrome	Species	Is_CellType_Marker
+DAPI	Nucleus	DAPI	Nucleus	DAPI	Mouse	FALSE
+FITC	Cytoplasm	B220	B cells	FAM	Mouse	TRUE
+CFP	Cytoplasm	CD4	CD4 T cells	DCC	Mouse	TRUE
+CY5	Cytoplasm	CD8	CD8 T cells	Cy5	Mouse	TRUE
+Alexa 594	Nucleus	Ki67	Proliferation	R610	Mouse	FALSE
+RFP	Cytoplasm	F4/80	Macrophages	R6G	Mouse	TRUE

--- a/quantifyIntensities.py
+++ b/quantifyIntensities.py
@@ -57,7 +57,10 @@ for name in tqdm(args.sample_names):
     if not os.path.exists(os.path.join(output_dir, 'quantification')):
         os.chdir(args.dir)
         print('Start quantification...')
-        run_command(f"{args.nextflow_dir} run labsyspharm/mcmicro --profile singularity --in {name} --start-at quantification --stop-at quantification --probability-maps mesmer --quant-opts '--masks nuclei.tif cytoplasm.tif'")
+        if args.nextflow_dir and os.path.exists(args.nextflow_dir):
+            run_command(f"{args.nextflow_dir} run --in {name} -profile singularity --start-at quantification --stop-at quantification --probability-maps mesmer --quant-opts '--masks nuclei.tif cytoplasm.tif' ")
+        else:
+            run_command(f"nextflow run labsyspharm/mcmicro -r 46abd97bc0 --in {name} -profile singularity --start-at quantification --stop-at quantification --probability-maps mesmer --quant-opts '--masks nuclei.tif cytoplasm.tif'")
 
         os.chdir(working_dir)
 

--- a/vsi2tiff.py
+++ b/vsi2tiff.py
@@ -61,7 +61,11 @@ try:
             output_path = os.path.join(args.output_dir, f'{sample_name}_{vsi_name}_acq{count:02d}.ome.tif')
             if os.path.exists(output_path):
                 os.remove(output_path)
-            run_command(f"{os.path.join(args.bftools_dir, 'bfconvert')} -option BF_MAXMEM 128g -series {i}  -bigtiff -pyramid-resolutions 1 {args.input_vsi} {output_path}")
+
+            if args.bftools_dir and os.path.exists(args.bftools_dir):
+                run_command(f"{os.path.join(args.bftools_dir, 'bfconvert')} -option BF_MAXMEM 128g -series {i}  -bigtiff -pyramid-resolutions 1 {args.input_vsi} {output_path}")
+            else:
+                run_command(f"bfconvert -option BF_MAXMEM 128g -series {i}  -bigtiff -pyramid-resolutions 1 {args.input_vsi} {output_path}")
             print(f'Acquisition {count} exported to {output_path}')
             print()
             count += 1


### PR DESCRIPTION
It's possible to define non-cell-type markers in the configuration talbe. Those markers will not be used for cell type classification, but their intensity will be used to divide cells into positive or negative for that marker. This is a generalization of the previous implementation, that was specific for Ki67 (proliferation marker).
   - The configuration tables must contain a new column called `Is_CellType_Marker` that can be either `TRUE` or `FALSE`.
   - The plots will not include `proliferating` vs `not proliferating`, but `marker+` vs `marker-`. The old proliferating cells are now `Ki67+`.
   - Neighborhood analyses does not require the `--celltype_query_proliferation_status` parameter anymore, but requires the the path to the configuration table using the parameter `--channel_info_path`.
   - Neighborhood analyses outputs plots and tables for cells negative for all markers, but also for cells positive for each marker individually. The file names also include the query cell type.